### PR TITLE
Crop Ryan founder photo to single image

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -97,6 +97,12 @@ body {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
 }
 
+.ryan-pic {
+  height: 320px;
+  object-fit: cover;
+  object-position: top;
+}
+
 .App-footer {
   background-color: #f1f1f1;
   color: #666;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders site title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByRole('heading', { name: /Hydroponics\.NYC/i });
+  expect(headingElement).toBeInTheDocument();
 });

--- a/src/Founders.js
+++ b/src/Founders.js
@@ -14,7 +14,7 @@ function Founders() {
 
       <section className="App-section" style={{ textAlign: 'center' }}>
         <h2>Ryan</h2>
-        <img src={ryanBabyPic} alt="Baby Ryan" className="baby-pic" />
+        <img src={ryanBabyPic} alt="Baby Ryan" className="baby-pic ryan-pic" />
         <p>A future CEO with snack time energy.</p>
 
         <h2>Sam</h2>


### PR DESCRIPTION
## Summary
- Crop Ryan's founder image to display only the first photo using a dedicated `ryan-pic` style
- Update unit test to verify the site title instead of a placeholder link

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689abeb038548325b1ebe0c040d4908a